### PR TITLE
manual-change-tracking

### DIFF
--- a/src/Bind.cs
+++ b/src/Bind.cs
@@ -23,525 +23,542 @@ using System.ComponentModel;
 
 namespace Praeclarum.Bind
 {
-	/// <summary>
-	/// Abstract class that represents bindings between values in an applications.
-	/// Binding are created using Create and removed by calling Unbind.
-	/// </summary>
-	public abstract class Binding
-	{
-		/// <summary>
-		/// Unbind this instance. This cannot be undone.
-		/// </summary>
-		public virtual void Unbind ()
-		{
-		}
-
-		/// <summary>
-		/// Uses the lambda expression to create data bindings.
-		/// Equality expression (==) become data bindings.
-		/// And expressions (&&) can be used to group the data bindings.
-		/// </summary>
-		/// <param name="specifications">The binding specifications.</param>
-		public static Binding Create<T> (Expression<Func<T>> specifications)
-		{
-			return BindExpression (specifications.Body);
-		}
-
-		static Binding BindExpression (Expression expr)
-		{
-			//
-			// Is this a group of bindings
-			//
-			if (expr.NodeType == ExpressionType.AndAlso) {
-
-				var b = (BinaryExpression)expr;
-
-				var parts = new List<Expression> ();
-
-				while (b != null) {
-					var l = b.Left;
-					parts.Add (b.Right);
-					if (l.NodeType == ExpressionType.AndAlso) {
-						b = (BinaryExpression)l;
-					} else {
-						parts.Add (l);
-						b = null;
-					}
-				}
-
-				parts.Reverse ();
-
-				return new MultipleBindings (parts.Select (BindExpression));
-			}
-
-			//
-			// Are we binding two values?
-			//
-			if (expr.NodeType == ExpressionType.Equal) {
-				var b = (BinaryExpression)expr;
-				return new EqualityBinding (b.Left, b.Right);
-			}
-
-			//
-			// This must be a new object binding (a template)
-			//
-			throw new NotSupportedException ("Only equality bindings are supported.");
-		}
-
-		protected static bool SetValue (Expression expr, object value, int changeId)
-		{
-			if (expr.NodeType == ExpressionType.MemberAccess) {				
-				var m = (MemberExpression)expr;
-				var mem = m.Member;
-
-				var target = Evaluator.EvalExpression (m.Expression);
-
-				var f = mem as FieldInfo;
-				var p = mem as PropertyInfo;
-
-				if (f != null) {
-					f.SetValue (target, value);
-				} else if (p != null) {
-					p.SetValue (target, value, null);
-				} else {
-					ReportError ("Trying to SetValue on " + mem.GetType () + " member");
-					return false;
-				}
-
-				InvalidateMember (target, mem, changeId);
-				return true;
-			}
-
-			ReportError ("Trying to SetValue on " + expr.NodeType + " expression");
-			return false;
-		}
-
-		public static event Action<string> Error = delegate {};
-
-		static void ReportError (string message)
-		{
-			Debug.WriteLine (message);
-			Error (message);
-		}
-
-		static void ReportError (object errorObject)
-		{
-			ReportError (errorObject.ToString ());
-		}
-
-		#region Change Notification
-
-		class MemberActions
-		{
-			readonly object target;
-			readonly MemberInfo member;
-
-			EventInfo eventInfo;
-			Delegate eventHandler;
-			
-			public MemberActions (object target, MemberInfo mem)
-			{
-				this.target = target;
-				member = mem;
-			}
-
-			void AddChangeNotificationEventHandler ()
-			{
-				if (target != null) {
-					var npc = target as INotifyPropertyChanged;
-					if (npc != null && (member is PropertyInfo)) {
-						npc.PropertyChanged += HandleNotifyPropertyChanged;
-					}
-					else {
-						AddHandlerForFirstExistingEvent (member.Name + "Changed", "EditingDidEnd", "ValueChanged", "Changed");
-//						if (!added) {
-//							Debug.WriteLine ("Failed to bind to change event for " + target);
-//						}
-					}
-				}
-			}
-
-			bool AddHandlerForFirstExistingEvent (params string[] names)
-			{
-				var type = target.GetType ();
-				foreach (var name in names) {
-					var ev = GetEvent (type, name);
-
-					if (ev != null) {
-						eventInfo = ev;
-						var isClassicHandler = typeof(EventHandler).GetTypeInfo ().IsAssignableFrom (ev.EventHandlerType.GetTypeInfo ());
-
-						eventHandler = isClassicHandler ? 
-							(EventHandler)HandleAnyEvent : 
-							CreateGenericEventHandler (ev, () => HandleAnyEvent (null, EventArgs.Empty));
-
-						ev.AddEventHandler(target, eventHandler);
-						Debug.WriteLine ("BIND: Added handler for {0} on {1}", eventInfo.Name, target);
-						return true;
-					}
-				}
-				return false;
-			}
-
-			static EventInfo GetEvent (Type type, string eventName)
-			{
-				var t = type;
-				while (t != null && t != typeof(object)) {
-					var ti = t.GetTypeInfo ();
-					var ev = t.GetTypeInfo ().GetDeclaredEvent (eventName);
-					if (ev != null)
-						return ev;
-					t = ti.BaseType;
-				}
-				return null;
-			}
-
-			static Delegate CreateGenericEventHandler (EventInfo evt, Action d)
-			{
-				var handlerType = evt.EventHandlerType;
-				var handlerTypeInfo = handlerType.GetTypeInfo ();
-				var handlerInvokeInfo = handlerTypeInfo.GetDeclaredMethod ("Invoke");
-				var eventParams = handlerInvokeInfo.GetParameters();
-
-				//lambda: (object x0, EventArgs x1) => d()
-				var parameters = eventParams.Select(p => Expression.Parameter(p.ParameterType, p.Name)).ToArray ();
-				var body = Expression.Call(Expression.Constant(d), d.GetType().GetTypeInfo ().GetDeclaredMethod ("Invoke"));
-				var lambda = Expression.Lambda(body, parameters);
-
-				var delegateInvokeInfo = lambda.Compile ().GetMethodInfo ();
-				return delegateInvokeInfo.CreateDelegate (handlerType, null);
-			}
-
-			void UnsubscribeFromChangeNotificationEvent ()
-			{
-				var npc = target as INotifyPropertyChanged;
-				if (npc != null && (member is PropertyInfo)) {
-					npc.PropertyChanged -= HandleNotifyPropertyChanged;
-					return;
-				}
-
-				if (eventInfo == null)
-					return;
-
-				eventInfo.RemoveEventHandler (target, eventHandler);
-
-				Debug.WriteLine ("BIND: Removed handler for {0} on {1}", eventInfo.Name, target);
-
-				eventInfo = null;
-				eventHandler = null;
-			}
-
-			void HandleNotifyPropertyChanged (object sender, PropertyChangedEventArgs e)
-			{
-				if (e.PropertyName == member.Name)
-					Binding.InvalidateMember (target, member);
-			}
-
-			void HandleAnyEvent (object sender, EventArgs e)
-			{
-				Binding.InvalidateMember (target, member);
-			}
-
-			readonly List<MemberChangeAction> actions = new List<MemberChangeAction> ();
-
-			/// <summary>
-			/// Add the specified action to be executed when Notify() is called.
-			/// </summary>
-			/// <param name="action">Action.</param>
-			public void AddAction (MemberChangeAction action)
-			{
-				if (actions.Count == 0) {
-					AddChangeNotificationEventHandler ();
-				}
-
-				actions.Add (action);
-			}
-
-			public void RemoveAction (MemberChangeAction action)
-			{
-				actions.Remove (action);
-
-				if (actions.Count == 0) {
-					UnsubscribeFromChangeNotificationEvent ();
-				}
-			}
-
-			/// <summary>
-			/// Execute all the actions.
-			/// </summary>
-			/// <param name="changeId">Change identifier.</param>
-			public void Notify (int changeId)
-			{
-				foreach (var s in actions) {
-					s.Notify (changeId);
-				}
-			}
-		}
-
-		static readonly Dictionary<Tuple<Object, MemberInfo>, MemberActions> objectSubs = new Dictionary<Tuple<Object, MemberInfo>, MemberActions> ();
-
-		internal static MemberChangeAction AddMemberChangeAction (object target, MemberInfo member, Action<int> k)
-		{
-			var key = Tuple.Create (target, member);
-			MemberActions subs;
-			if (!objectSubs.TryGetValue (key, out subs)) {
-				subs = new MemberActions (target, member);
-				objectSubs.Add (key, subs);
-			}
-
-//			Debug.WriteLine ("ADD CHANGE ACTION " + target + " " + member);
-			var sub = new MemberChangeAction (target, member, k);
-			subs.AddAction (sub);
-			return sub;
-		}
-
-		internal static void RemoveMemberChangeAction (MemberChangeAction sub)
-		{
-			var key = Tuple.Create (sub.Target, sub.Member);
-			MemberActions subs;
-			if (objectSubs.TryGetValue (key, out subs)) {
-//				Debug.WriteLine ("REMOVE CHANGE ACTION " + sub.Target + " " + sub.Member);
-				subs.RemoveAction (sub);
-			}
-		}
-
-		/// <summary>
-		/// Invalidate the specified object member. This will cause all actions
-		/// associated with that member to be executed.
-		/// This is the main mechanism by which binding values are distributed.
-		/// </summary>
-		/// <param name="target">Target object</param>
-		/// <param name="member">Member of the object that changed</param>
-		/// <param name="changeId">Change identifier</param>
-		public static void InvalidateMember (object target, MemberInfo member, int changeId = 0)
-		{
-			var key = Tuple.Create (target, member);
-			MemberActions subs;
-			if (objectSubs.TryGetValue (key, out subs)) {
-//				Debug.WriteLine ("INVALIDATE {0} {1}", target, member.Name);
-				subs.Notify (changeId);
-			}
-		}
-
-		#endregion
-	}
-
-
-	/// <summary>
-	/// An action tied to a particular member of an object.
-	/// When Notify is called, the action is executed.
-	/// </summary>
-	class MemberChangeAction
-	{
-		readonly Action<int> action;
-
-		public object Target { get; private set; }
-		public MemberInfo Member { get; private set; }
-
-		public MemberChangeAction (object target, MemberInfo member, Action<int> action)
-		{
-			Target = target;
-			if (member == null)
-				throw new ArgumentNullException ("member");
-			Member = member;
-			if (action == null)
-				throw new ArgumentNullException ("action");
-			this.action = action;
-		}
-
-		public void Notify (int changeId)
-		{
-			action (changeId);
-		}
-	}
-
-
-	/// <summary>
-	/// Methods that can evaluate Linq expressions.
-	/// </summary>
-	static class Evaluator
-	{
-		/// <summary>
-		/// Gets the value of a Linq expression.
-		/// </summary>
-		/// <param name="expr">The expresssion.</param>
-		public static object EvalExpression (Expression expr)
-		{
-			//
-			// Easy case
-			//
-			if (expr.NodeType == ExpressionType.Constant) {
-				return ((ConstantExpression)expr).Value;
-			}
-			
-			//
-			// General case
-			//
-//			Debug.WriteLine ("WARNING EVAL COMPILED {0}", expr);
-			var lambda = Expression.Lambda (expr, Enumerable.Empty<ParameterExpression> ());
-			return lambda.Compile ().DynamicInvoke ();
-		}
-	}
-
-	/// <summary>
-	/// Binding between two values. When one changes, the other
-	/// is set.
-	/// </summary>
-	class EqualityBinding : Binding
-	{
-		object Value;
-
-		class Trigger
-		{
-			public Expression Expression;
-			public MemberInfo Member;
-			public MemberChangeAction ChangeAction;
-		}
-		
-		readonly List<Trigger> leftTriggers = new List<Trigger> ();
-		readonly List<Trigger> rightTriggers = new List<Trigger> ();
-		
-		public EqualityBinding (Expression left, Expression right)
-		{
-			// Try evaling the right and assigning left
-			Value = Evaluator.EvalExpression (right);
-			var leftSet = SetValue (left, Value, nextChangeId);
-
-			// If that didn't work, then try the other direction
-			if (!leftSet) {
-				Value = Evaluator.EvalExpression (left);
-				SetValue (right, Value, nextChangeId);
-			}
-
-			nextChangeId++;
-
-			CollectTriggers (left, leftTriggers);
-			CollectTriggers (right, rightTriggers);
-
-			Resubscribe (leftTriggers, left, right);
-			Resubscribe (rightTriggers, right, left);
-		}
-
-		public override void Unbind ()
-		{
-			Unsubscribe (leftTriggers);
-			Unsubscribe (rightTriggers);
-			base.Unbind ();
-		}
-
-		void Resubscribe (List<Trigger> triggers, Expression expr, Expression dependentExpr)
-		{
-			Unsubscribe (triggers);
-			Subscribe (triggers, changeId => OnSideChanged (expr, dependentExpr, changeId));
-		}
-
-		int nextChangeId = 1;
-		readonly HashSet<int> activeChangeIds = new HashSet<int> ();
-		
-		void OnSideChanged (Expression expr, Expression dependentExpr, int causeChangeId)
-		{
-			if (activeChangeIds.Contains (causeChangeId))
-				return;
-
-			var v = Evaluator.EvalExpression (expr);
-			
-			if (v == null && Value == null)
-				return;
-			
-			if ((v == null && Value != null) ||
-				(v != null && Value == null) ||
-				((v is IComparable) && ((IComparable)v).CompareTo (Value) != 0)) {
-				
-				Value = v;
-
-				var changeId = nextChangeId++;
-				activeChangeIds.Add (changeId);
-				SetValue (dependentExpr, v, changeId);
-				activeChangeIds.Remove (changeId);
-			} 
-//			else {
-//				Debug.WriteLine ("Prevented needless update");
-//			}
-		}
-
-		static void Unsubscribe (List<Trigger> triggers)
-		{
-			foreach (var t in triggers) {
-				if (t.ChangeAction != null) {
-					RemoveMemberChangeAction (t.ChangeAction);
-				}
-			}
-		}
-		
-		static void Subscribe (List<Trigger> triggers, Action<int> action)
-		{
-			foreach (var t in triggers) {
-				t.ChangeAction = AddMemberChangeAction (Evaluator.EvalExpression (t.Expression), t.Member, action);
-			}
-		}		
-		
-		void CollectTriggers (Expression s, List<Trigger> triggers)
-		{
-			if (s.NodeType == ExpressionType.MemberAccess) {
-				
-				var m = (MemberExpression)s;
-				CollectTriggers (m.Expression, triggers);
-				var t = new Trigger { Expression = m.Expression, Member = m.Member };
-				triggers.Add (t);
-
-			} else {
-				var b = s as BinaryExpression;
-				if (b != null) {
-					CollectTriggers (b.Left, triggers);
-					CollectTriggers (b.Right, triggers);
-				}
-			}
-		}
-	}
-
-
-	/// <summary>
-	/// Multiple bindings grouped under a single binding to make adding and removing easier.
-	/// </summary>
-	class MultipleBindings : Binding
-	{
-		readonly List<Binding> bindings;
-
-		public MultipleBindings (IEnumerable<Binding> bindings)
-		{
-			this.bindings = bindings.Where (x => x != null).ToList ();
-		}
-
-		public override void Unbind ()
-		{
-			base.Unbind ();
-			foreach (var b in bindings) {
-				b.Unbind ();
-			}
-			bindings.Clear ();
-		}
-	}
-
-	#if __IOS__
-	[MonoTouch.Foundation.Preserve]
-	static class PreserveEventsAndSettersHack
-	{
-		[MonoTouch.Foundation.Preserve]
-		static void Hack ()
-		{
-			var l = new MonoTouch.UIKit.UILabel ();
-			l.Text = l.Text + "";
-
-			var tf = new MonoTouch.UIKit.UITextField ();
-			tf.Text = tf.Text + "";
-			tf.EditingDidEnd += delegate {};
-			tf.ValueChanged += delegate {};
-
-			var vc = new MonoTouch.UIKit.UIViewController ();
-			vc.Title = vc.Title + "";
-			vc.Editing = !vc.Editing;
-		}
-	}
-	#endif
+    /// <summary>
+    /// Abstract class that represents bindings between values in an applications.
+    /// Binding are created using Create and removed by calling Unbind.
+    /// </summary>
+    public abstract class Binding
+    {
+        /// <summary>
+        /// Unbind this instance. This cannot be undone.
+        /// </summary>
+        public virtual void Unbind ()
+        {
+        }
+
+        /// <summary>
+        /// Uses the lambda expression to create data bindings.
+        /// Equality expression (==) become data bindings.
+        /// And expressions (&&) can be used to group the data bindings.
+        /// </summary>
+        /// <param name="specifications">The binding specifications.</param>
+        public static Binding Create<T> (Expression<Func<T>> specifications)
+        {
+            return BindExpression (specifications.Body);
+        }
+
+        static Binding BindExpression (Expression expr)
+        {
+            //
+            // Is this a group of bindings
+            //
+            if (expr.NodeType == ExpressionType.AndAlso) {
+
+                var b = (BinaryExpression)expr;
+
+                var parts = new List<Expression> ();
+
+                while (b != null) {
+                    var l = b.Left;
+                    parts.Add (b.Right);
+                    if (l.NodeType == ExpressionType.AndAlso) {
+                        b = (BinaryExpression)l;
+                    } else {
+                        parts.Add (l);
+                        b = null;
+                    }
+                }
+
+                parts.Reverse ();
+
+                return new MultipleBindings (parts.Select (BindExpression));
+            }
+
+            //
+            // Are we binding two values?
+            //
+            if (expr.NodeType == ExpressionType.Equal) {
+                var b = (BinaryExpression)expr;
+                return new EqualityBinding (b.Left, b.Right);
+            }
+
+            //
+            // This must be a new object binding (a template)
+            //
+            throw new NotSupportedException ("Only equality bindings are supported.");
+        }
+
+        protected static bool SetValue (Expression expr, object value, int changeId)
+        {
+            if (expr.NodeType == ExpressionType.MemberAccess) {             
+                var m = (MemberExpression)expr;
+                var mem = m.Member;
+
+                var target = Evaluator.EvalExpression (m.Expression);
+
+                var f = mem as FieldInfo;
+                var p = mem as PropertyInfo;
+
+                if (f != null) {
+                    f.SetValue (target, value);
+                } else if (p != null) {
+                    p.SetValue (target, value, null);
+                } else {
+                    ReportError ("Trying to SetValue on " + mem.GetType () + " member");
+                    return false;
+                }
+
+                InvalidateMember (target, mem, changeId);
+                return true;
+            }
+
+            ReportError ("Trying to SetValue on " + expr.NodeType + " expression");
+            return false;
+        }
+
+        public static event Action<string> Error = delegate {};
+
+        static void ReportError (string message)
+        {
+            Debug.WriteLine (message);
+            Error (message);
+        }
+
+        static void ReportError (object errorObject)
+        {
+            ReportError (errorObject.ToString ());
+        }
+
+        #region Change Notification
+
+        class MemberActions
+        {
+            readonly object target;
+            readonly MemberInfo member;
+
+            EventInfo eventInfo;
+            Delegate eventHandler;
+
+            public MemberActions (object target, MemberInfo mem)
+            {
+                this.target = target;
+                member = mem;
+            }
+
+            void AddChangeNotificationEventHandler ()
+            {
+                if (target != null) {
+                    var npc = target as INotifyPropertyChanged;
+                    if (npc != null && (member is PropertyInfo)) {
+                        npc.PropertyChanged += HandleNotifyPropertyChanged;
+                    }
+                    else {
+                        AddHandlerForFirstExistingEvent (member.Name + "Changed", "EditingDidEnd", "ValueChanged", "Changed");
+                        //                      if (!added) {
+                        //                          Debug.WriteLine ("Failed to bind to change event for " + target);
+                        //                      }
+                    }
+                }
+            }
+
+            bool AddHandlerForFirstExistingEvent (params string[] names)
+            {
+                var type = target.GetType ();
+                foreach (var name in names) {
+                    var ev = GetEvent (type, name);
+
+                    if (ev != null) {
+                        eventInfo = ev;
+                        var isClassicHandler = typeof(EventHandler).GetTypeInfo ().IsAssignableFrom (ev.EventHandlerType.GetTypeInfo ());
+
+                        eventHandler = isClassicHandler ? 
+                            (EventHandler)HandleAnyEvent : 
+                            CreateGenericEventHandler (ev, () => HandleAnyEvent (null, EventArgs.Empty));
+
+                        ev.AddEventHandler(target, eventHandler);
+                        Debug.WriteLine ("BIND: Added handler for {0} on {1}", eventInfo.Name, target);
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            static EventInfo GetEvent (Type type, string eventName)
+            {
+                var t = type;
+                while (t != null && t != typeof(object)) {
+                    var ti = t.GetTypeInfo ();
+                    var ev = t.GetTypeInfo ().GetDeclaredEvent (eventName);
+                    if (ev != null)
+                        return ev;
+                    t = ti.BaseType;
+                }
+                return null;
+            }
+
+            static Delegate CreateGenericEventHandler (EventInfo evt, Action d)
+            {
+                var handlerType = evt.EventHandlerType;
+                var handlerTypeInfo = handlerType.GetTypeInfo ();
+                var handlerInvokeInfo = handlerTypeInfo.GetDeclaredMethod ("Invoke");
+                var eventParams = handlerInvokeInfo.GetParameters();
+
+                //lambda: (object x0, EventArgs x1) => d()
+                var parameters = eventParams.Select(p => Expression.Parameter(p.ParameterType, p.Name)).ToArray ();
+                var body = Expression.Call(Expression.Constant(d), d.GetType().GetTypeInfo ().GetDeclaredMethod ("Invoke"));
+                var lambda = Expression.Lambda(body, parameters);
+
+                var delegateInvokeInfo = lambda.Compile ().GetMethodInfo ();
+                return delegateInvokeInfo.CreateDelegate (handlerType, null);
+            }
+
+            void UnsubscribeFromChangeNotificationEvent ()
+            {
+                var npc = target as INotifyPropertyChanged;
+                if (npc != null && (member is PropertyInfo)) {
+                    npc.PropertyChanged -= HandleNotifyPropertyChanged;
+                    return;
+                }
+
+                if (eventInfo == null)
+                    return;
+
+                eventInfo.RemoveEventHandler (target, eventHandler);
+
+                Debug.WriteLine ("BIND: Removed handler for {0} on {1}", eventInfo.Name, target);
+
+                eventInfo = null;
+                eventHandler = null;
+            }
+
+            void HandleNotifyPropertyChanged (object sender, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == member.Name)
+                    Binding.InvalidateMember (target, member);
+            }
+
+            void HandleAnyEvent (object sender, EventArgs e)
+            {
+                Binding.InvalidateMember (target, member);
+            }
+
+            readonly List<MemberChangeAction> actions = new List<MemberChangeAction> ();
+
+            /// <summary>
+            /// Add the specified action to be executed when Notify() is called.
+            /// </summary>
+            /// <param name="action">Action.</param>
+            public void AddAction (MemberChangeAction action)
+            {
+                if (actions.Count == 0) {
+                    AddChangeNotificationEventHandler ();
+                }
+
+                actions.Add (action);
+            }
+
+            public void RemoveAction (MemberChangeAction action)
+            {
+                actions.Remove (action);
+
+                if (actions.Count == 0) {
+                    UnsubscribeFromChangeNotificationEvent ();
+                }
+            }
+
+            /// <summary>
+            /// Execute all the actions.
+            /// </summary>
+            /// <param name="changeId">Change identifier.</param>
+            public void Notify (int changeId)
+            {
+                foreach (var s in actions) {
+                    s.Notify (changeId);
+                }
+            }
+        }
+
+        static readonly Dictionary<Tuple<Object, MemberInfo>, MemberActions> objectSubs = new Dictionary<Tuple<Object, MemberInfo>, MemberActions> ();
+
+        internal static MemberChangeAction AddMemberChangeAction (object target, MemberInfo member, Action<int> k)
+        {
+            var key = Tuple.Create (target, member);
+            MemberActions subs;
+            if (!objectSubs.TryGetValue (key, out subs)) {
+                subs = new MemberActions (target, member);
+                objectSubs.Add (key, subs);
+            }
+
+            //          Debug.WriteLine ("ADD CHANGE ACTION " + target + " " + member);
+            var sub = new MemberChangeAction (target, member, k);
+            subs.AddAction (sub);
+            return sub;
+        }
+
+        internal static void RemoveMemberChangeAction (MemberChangeAction sub)
+        {
+            var key = Tuple.Create (sub.Target, sub.Member);
+            MemberActions subs;
+            if (objectSubs.TryGetValue (key, out subs)) {
+                //              Debug.WriteLine ("REMOVE CHANGE ACTION " + sub.Target + " " + sub.Member);
+                subs.RemoveAction (sub);
+            }
+        }
+
+        /// <summary>
+        /// Invalidate the specified object member. This will cause all actions
+        /// associated with that member to be executed.
+        /// This is the main mechanism by which binding values are distributed.
+        /// </summary>
+        /// <param name="target">Target object</param>
+        /// <param name="member">Member of the object that changed</param>
+        /// <param name="changeId">Change identifier</param>
+        public static void InvalidateMember (object target, MemberInfo member, int changeId = 0)
+        {
+            var key = Tuple.Create (target, member);
+            MemberActions subs;
+            if (objectSubs.TryGetValue (key, out subs)) {
+                //              Debug.WriteLine ("INVALIDATE {0} {1}", target, member.Name);
+                subs.Notify (changeId);
+            }
+        }
+
+        /// <summary>
+        /// A nice expression based way to invalidate the specified object member. 
+        /// This will cause all actions associated with that member to be executed.
+        /// This is the main mechanism by which binding values are distributed.
+        /// </summary>
+        /// <param name="lambdaExpr">Lambda expr of the Member of the object that changed</param>
+        /// <typeparam name="T">The 1st type parameter.</typeparam>
+        public static void InvalidateMember<T>(Expression<Func<T>> lambdaExpr)
+        {
+            var body = lambdaExpr.Body;
+            if (body.NodeType == ExpressionType.MemberAccess) {
+                var m = (MemberExpression)body;
+                var obj = Evaluator.EvalExpression(m.Expression);
+                InvalidateMember(obj, m.Member, 0);
+            }
+        }
+
+        #endregion
+    }
+
+
+    /// <summary>
+    /// An action tied to a particular member of an object.
+    /// When Notify is called, the action is executed.
+    /// </summary>
+    class MemberChangeAction
+    {
+        readonly Action<int> action;
+
+        public object Target { get; private set; }
+        public MemberInfo Member { get; private set; }
+
+        public MemberChangeAction (object target, MemberInfo member, Action<int> action)
+        {
+            Target = target;
+            if (member == null)
+                throw new ArgumentNullException ("member");
+            Member = member;
+            if (action == null)
+                throw new ArgumentNullException ("action");
+            this.action = action;
+        }
+
+        public void Notify (int changeId)
+        {
+            action (changeId);
+        }
+    }
+
+
+    /// <summary>
+    /// Methods that can evaluate Linq expressions.
+    /// </summary>
+    static class Evaluator
+    {
+        /// <summary>
+        /// Gets the value of a Linq expression.
+        /// </summary>
+        /// <param name="expr">The expresssion.</param>
+        public static object EvalExpression (Expression expr)
+        {
+            //
+            // Easy case
+            //
+            if (expr.NodeType == ExpressionType.Constant) {
+                return ((ConstantExpression)expr).Value;
+            }
+
+            //
+            // General case
+            //
+            //          Debug.WriteLine ("WARNING EVAL COMPILED {0}", expr);
+            var lambda = Expression.Lambda (expr, Enumerable.Empty<ParameterExpression> ());
+            return lambda.Compile ().DynamicInvoke ();
+        }
+    }
+
+    /// <summary>
+    /// Binding between two values. When one changes, the other
+    /// is set.
+    /// </summary>
+    class EqualityBinding : Binding
+    {
+        object Value;
+
+        class Trigger
+        {
+            public Expression Expression;
+            public MemberInfo Member;
+            public MemberChangeAction ChangeAction;
+        }
+
+        readonly List<Trigger> leftTriggers = new List<Trigger> ();
+        readonly List<Trigger> rightTriggers = new List<Trigger> ();
+
+        public EqualityBinding (Expression left, Expression right)
+        {
+            // Try evaling the right and assigning left
+            Value = Evaluator.EvalExpression (right);
+            var leftSet = SetValue (left, Value, nextChangeId);
+
+            // If that didn't work, then try the other direction
+            if (!leftSet) {
+                Value = Evaluator.EvalExpression (left);
+                SetValue (right, Value, nextChangeId);
+            }
+
+            nextChangeId++;
+
+            CollectTriggers (left, leftTriggers);
+            CollectTriggers (right, rightTriggers);
+
+            Resubscribe (leftTriggers, left, right);
+            Resubscribe (rightTriggers, right, left);
+        }
+
+        public override void Unbind ()
+        {
+            Unsubscribe (leftTriggers);
+            Unsubscribe (rightTriggers);
+            base.Unbind ();
+        }
+
+        void Resubscribe (List<Trigger> triggers, Expression expr, Expression dependentExpr)
+        {
+            Unsubscribe (triggers);
+            Subscribe (triggers, changeId => OnSideChanged (expr, dependentExpr, changeId));
+        }
+
+        int nextChangeId = 1;
+        readonly HashSet<int> activeChangeIds = new HashSet<int> ();
+
+        void OnSideChanged (Expression expr, Expression dependentExpr, int causeChangeId)
+        {
+            if (activeChangeIds.Contains (causeChangeId))
+                return;
+
+            var v = Evaluator.EvalExpression (expr);
+
+            if (v == null && Value == null)
+                return;
+
+            if ((v == null && Value != null) ||
+                (v != null && Value == null) ||
+                ((v is IComparable) && ((IComparable)v).CompareTo (Value) != 0)) {
+
+                Value = v;
+
+                var changeId = nextChangeId++;
+                activeChangeIds.Add (changeId);
+                SetValue (dependentExpr, v, changeId);
+                activeChangeIds.Remove (changeId);
+            } 
+            //          else {
+            //              Debug.WriteLine ("Prevented needless update");
+            //          }
+        }
+
+        static void Unsubscribe (List<Trigger> triggers)
+        {
+            foreach (var t in triggers) {
+                if (t.ChangeAction != null) {
+                    RemoveMemberChangeAction (t.ChangeAction);
+                }
+            }
+        }
+
+        static void Subscribe (List<Trigger> triggers, Action<int> action)
+        {
+            foreach (var t in triggers) {
+                t.ChangeAction = AddMemberChangeAction (Evaluator.EvalExpression (t.Expression), t.Member, action);
+            }
+        }       
+
+        void CollectTriggers (Expression s, List<Trigger> triggers)
+        {
+            if (s.NodeType == ExpressionType.MemberAccess) {
+
+                var m = (MemberExpression)s;
+                CollectTriggers (m.Expression, triggers);
+                var t = new Trigger { Expression = m.Expression, Member = m.Member };
+                triggers.Add (t);
+
+            } else {
+                var b = s as BinaryExpression;
+                if (b != null) {
+                    CollectTriggers (b.Left, triggers);
+                    CollectTriggers (b.Right, triggers);
+                }
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Multiple bindings grouped under a single binding to make adding and removing easier.
+    /// </summary>
+    class MultipleBindings : Binding
+    {
+        readonly List<Binding> bindings;
+
+        public MultipleBindings (IEnumerable<Binding> bindings)
+        {
+            this.bindings = bindings.Where (x => x != null).ToList ();
+        }
+
+        public override void Unbind ()
+        {
+            base.Unbind ();
+            foreach (var b in bindings) {
+                b.Unbind ();
+            }
+            bindings.Clear ();
+        }
+    }
+
+    #if __IOS__
+    [MonoTouch.Foundation.Preserve]
+    static class PreserveEventsAndSettersHack
+    {
+    [MonoTouch.Foundation.Preserve]
+    static void Hack ()
+    {
+    var l = new MonoTouch.UIKit.UILabel ();
+    l.Text = l.Text + "";
+
+    var tf = new MonoTouch.UIKit.UITextField ();
+    tf.Text = tf.Text + "";
+    tf.EditingDidEnd += delegate {};
+    tf.ValueChanged += delegate {};
+
+    var vc = new MonoTouch.UIKit.UIViewController ();
+    vc.Title = vc.Title + "";
+    vc.Editing = !vc.Editing;
+    }
+    }
+    #endif
 }
 

--- a/test/ChangeTrackingTest.cs
+++ b/test/ChangeTrackingTest.cs
@@ -4,334 +4,364 @@ using System.ComponentModel;
 
 namespace Praeclarum.Bind.Test
 {
-	[TestFixture]
-	public class ChangeTrackingTest
-	{
-		[SetUp]
-		public void SetUp ()
-		{
-			Binding.Error += message => Console.WriteLine (message);
-		}
-
-		class PropertyChangedEventObject
-		{
-			string stringValue = "";
-
-			public int StringValueChangedCount { get; private set; }
-
-			EventHandler stringValueChanged; 
-			public event EventHandler StringValueChanged 
-			{ 
-				add {
-					stringValueChanged += value;
-					StringValueChangedCount++;
-				} 
-				remove {
-					stringValueChanged -= value;
-					StringValueChangedCount--;
-				}
-			} 
-
-			public string StringValue {
-				get { return stringValue; }
-				set {
-					if (stringValue != value) {
-						stringValue = value;
-						if (stringValueChanged != null) {
-							stringValueChanged (this, EventArgs.Empty);
-						}
-					}
-				}
-			}
-		}
+    [TestFixture]
+    public class ChangeTrackingTest
+    {
+        [SetUp]
+        public void SetUp ()
+        {
+            Binding.Error += message => Console.WriteLine (message);
+        }
+
+        class PropertyChangedEventObject
+        {
+            string stringValue = "";
+
+            public int StringValueChangedCount { get; private set; }
+
+            EventHandler stringValueChanged; 
+            public event EventHandler StringValueChanged 
+            { 
+                add {
+                    stringValueChanged += value;
+                    StringValueChangedCount++;
+                } 
+                remove {
+                    stringValueChanged -= value;
+                    StringValueChangedCount--;
+                }
+            } 
+
+            public string StringValue {
+                get { return stringValue; }
+                set {
+                    if (stringValue != value) {
+                        stringValue = value;
+                        if (stringValueChanged != null) {
+                            stringValueChanged (this, EventArgs.Empty);
+                        }
+                    }
+                }
+            }
+        }
 
-		[Test]
-		public void PropertyChanged ()
-		{
-			var obj = new PropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var left = "";
+        [Test]
+        public void PropertyChanged ()
+        {
+            var obj = new PropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var left = "";
 
-			Binding.Create (() => left == obj.StringValue);
+            Binding.Create (() => left == obj.StringValue);
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual (obj.StringValue, left);
-		}
+            Assert.AreEqual (obj.StringValue, left);
+        }
 
-		[Test]
-		public void MultipleObjectPropertyChanged ()
-		{
-			var objA = new PropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var objB = new PropertyChangedEventObject {
-				StringValue = "World",
-			};
-			var left = "";
+        [Test]
+        public void MultipleObjectPropertyChanged ()
+        {
+            var objA = new PropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var objB = new PropertyChangedEventObject {
+                StringValue = "World",
+            };
+            var left = "";
 
-			Binding.Create (() => left == objA.StringValue + ", " + objB.StringValue);
+            Binding.Create (() => left == objA.StringValue + ", " + objB.StringValue);
 
-			Assert.AreEqual ("Hello, World", left);
+            Assert.AreEqual ("Hello, World", left);
 
-			objA.StringValue = "Goodbye";
+            objA.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye, World", left);
+            Assert.AreEqual ("Goodbye, World", left);
 
-			objB.StringValue = "Mars";
+            objB.StringValue = "Mars";
 
-			Assert.AreEqual ("Goodbye, Mars", left);
+            Assert.AreEqual ("Goodbye, Mars", left);
 
-		}
+        }
 
-		[Test]
-		public void MultiplePropertyChanged ()
-		{
-			var obj = new PropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var leftA = "";
-			var leftB = "";
+        [Test]
+        public void MultiplePropertyChanged ()
+        {
+            var obj = new PropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var leftA = "";
+            var leftB = "";
 
-			Binding.Create (() => leftA == obj.StringValue);
-			Binding.Create (() => leftB == obj.StringValue + "...");
+            Binding.Create (() => leftA == obj.StringValue);
+            Binding.Create (() => leftB == obj.StringValue + "...");
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			Assert.AreEqual ("Hello", leftA);
-			Assert.AreEqual ("Hello...", leftB);
+            Assert.AreEqual ("Hello", leftA);
+            Assert.AreEqual ("Hello...", leftB);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye", leftA);
-			Assert.AreEqual ("Goodbye...", leftB);
-		}
+            Assert.AreEqual ("Goodbye", leftA);
+            Assert.AreEqual ("Goodbye...", leftB);
+        }
 
-		[Test]
-		public void RemoveMultiplePropertyChanged ()
-		{
-			var obj = new PropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var leftA = "";
-			var leftB = "";
+        [Test]
+        public void RemoveMultiplePropertyChanged ()
+        {
+            var obj = new PropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var leftA = "";
+            var leftB = "";
 
-			var bA = Binding.Create (() => leftA == obj.StringValue);
-			var bB = Binding.Create (() => leftB == obj.StringValue + "...");
+            var bA = Binding.Create (() => leftA == obj.StringValue);
+            var bB = Binding.Create (() => leftB == obj.StringValue + "...");
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			Assert.AreEqual ("Hello", leftA);
-			Assert.AreEqual ("Hello...", leftB);
+            Assert.AreEqual ("Hello", leftA);
+            Assert.AreEqual ("Hello...", leftB);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye", leftA);
-			Assert.AreEqual ("Goodbye...", leftB);
+            Assert.AreEqual ("Goodbye", leftA);
+            Assert.AreEqual ("Goodbye...", leftB);
 
-			bA.Unbind ();
+            bA.Unbind ();
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			obj.StringValue = "Hello Again";
+            obj.StringValue = "Hello Again";
 
-			Assert.AreEqual ("Goodbye", leftA);
-			Assert.AreEqual ("Hello Again...", leftB);
+            Assert.AreEqual ("Goodbye", leftA);
+            Assert.AreEqual ("Hello Again...", leftB);
 
-			bB.Unbind ();
+            bB.Unbind ();
 
-			Assert.AreEqual (0, obj.StringValueChangedCount);
+            Assert.AreEqual (0, obj.StringValueChangedCount);
 
-			obj.StringValue = "Goodbye Again";
+            obj.StringValue = "Goodbye Again";
 
-			Assert.AreEqual ("Goodbye", leftA);
-			Assert.AreEqual ("Hello Again...", leftB);
-		}
+            Assert.AreEqual ("Goodbye", leftA);
+            Assert.AreEqual ("Hello Again...", leftB);
+        }
 
 
-		[Test]
-		public void RemovePropertyChanged ()
-		{
-			var obj = new PropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var left = "";
+        [Test]
+        public void RemovePropertyChanged ()
+        {
+            var obj = new PropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var left = "";
 
-			var b = Binding.Create (() => left == obj.StringValue);
+            var b = Binding.Create (() => left == obj.StringValue);
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			b.Unbind ();
+            b.Unbind ();
 
-			Assert.AreEqual (0, obj.StringValueChangedCount);
+            Assert.AreEqual (0, obj.StringValueChangedCount);
 
-			obj.StringValue = "Hello Again";
+            obj.StringValue = "Hello Again";
 
-			Assert.AreEqual ("Goodbye", left);
-		}
+            Assert.AreEqual ("Goodbye", left);
+        }
 
-		class NotifyPropertyChangedEventObject : INotifyPropertyChanged
-		{
-			public int PropertyChangedCount { get; private set; }
+        class NotifyPropertyChangedEventObject : INotifyPropertyChanged
+        {
+            public int PropertyChangedCount { get; private set; }
 
-			PropertyChangedEventHandler propertyChanged; 
-			public event PropertyChangedEventHandler PropertyChanged 
-			{ 
-				add {
-					propertyChanged += value;
-					PropertyChangedCount++;
-				} 
-				remove {
-					propertyChanged -= value;
-					PropertyChangedCount--;
-				}
-			} 
+            PropertyChangedEventHandler propertyChanged; 
+            public event PropertyChangedEventHandler PropertyChanged 
+            { 
+                add {
+                    propertyChanged += value;
+                    PropertyChangedCount++;
+                } 
+                remove {
+                    propertyChanged -= value;
+                    PropertyChangedCount--;
+                }
+            } 
 
-			string stringValue = "";
+            string stringValue = "";
 
-			public string StringValue {
-				get { return stringValue; }
-				set {
-					if (stringValue != value) {
-						stringValue = value;
-						if (propertyChanged != null) {
-							propertyChanged (this, new PropertyChangedEventArgs ("StringValue"));
-						}
-					}
-				}
-			}
+            public string StringValue {
+                get { return stringValue; }
+                set {
+                    if (stringValue != value) {
+                        stringValue = value;
+                        if (propertyChanged != null) {
+                            propertyChanged (this, new PropertyChangedEventArgs ("StringValue"));
+                        }
+                    }
+                }
+            }
 
-			int intValue = 0;
+            int intValue = 0;
 
-			public int IntValue {
-				get { return intValue; }
-				set {
-					if (intValue != value) {
-						intValue = value;
-						if (propertyChanged != null) {
-							propertyChanged (this, new PropertyChangedEventArgs ("IntValue"));
-						}
-					}
-				}
-			}
-		}
+            public int IntValue {
+                get { return intValue; }
+                set {
+                    if (intValue != value) {
+                        intValue = value;
+                        if (propertyChanged != null) {
+                            propertyChanged (this, new PropertyChangedEventArgs ("IntValue"));
+                        }
+                    }
+                }
+            }
+        }
 
-		[Test]
-		public void NotifyPropertyChanged ()
-		{
-			var obj = new NotifyPropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var left = "";
+        [Test]
+        public void NotifyPropertyChanged ()
+        {
+            var obj = new NotifyPropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var left = "";
 
-			Binding.Create (() => left == obj.StringValue);
+            Binding.Create (() => left == obj.StringValue);
 
-			Assert.AreEqual (1, obj.PropertyChangedCount);
+            Assert.AreEqual (1, obj.PropertyChangedCount);
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye", left);
-		}
+            Assert.AreEqual ("Goodbye", left);
+        }
 
-		[Test]
-		public void RemoveNotifyPropertyChanged ()
-		{
-			var obj = new NotifyPropertyChangedEventObject {
-				StringValue = "Hello",
-			};
-			var left = "";
+        [Test]
+        public void RemoveNotifyPropertyChanged ()
+        {
+            var obj = new NotifyPropertyChangedEventObject {
+                StringValue = "Hello",
+            };
+            var left = "";
 
-			var b = Binding.Create (() => left == obj.StringValue);
+            var b = Binding.Create (() => left == obj.StringValue);
 
-			Assert.AreEqual (1, obj.PropertyChangedCount);
+            Assert.AreEqual (1, obj.PropertyChangedCount);
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye", left);
+            Assert.AreEqual ("Goodbye", left);
 
-			b.Unbind ();
+            b.Unbind ();
 
-			Assert.AreEqual (0, obj.PropertyChangedCount);
+            Assert.AreEqual (0, obj.PropertyChangedCount);
 
-			obj.StringValue = "Hello Again";
+            obj.StringValue = "Hello Again";
 
-			Assert.AreEqual ("Goodbye", left);
-		}
+            Assert.AreEqual ("Goodbye", left);
+        }
 
-		class NotEventHandlerObject
-		{
-			string stringValue = "";
+        class NotEventHandlerObject
+        {
+            string stringValue = "";
 
-			public int StringValueChangedCount { get; private set; }
+            public int StringValueChangedCount { get; private set; }
 
-			Action<string, string> stringValueChanged; 
-			public event Action<string, string> StringValueChanged 
-			{ 
-				add {
-					stringValueChanged += value;
-					StringValueChangedCount++;
-				} 
-				remove {
-					stringValueChanged -= value;
-					StringValueChangedCount--;
-				}
-			} 
+            Action<string, string> stringValueChanged; 
+            public event Action<string, string> StringValueChanged 
+            { 
+                add {
+                    stringValueChanged += value;
+                    StringValueChangedCount++;
+                } 
+                remove {
+                    stringValueChanged -= value;
+                    StringValueChangedCount--;
+                }
+            } 
 
-			public string StringValue {
-				get { return stringValue; }
-				set {
-					if (stringValue != value) {
-						var oldValue = stringValue;
-						stringValue = value;
-						if (stringValueChanged != null) {
-							stringValueChanged (oldValue, stringValue);
-						}
-					}
-				}
-			}
-		}
+            public string StringValue {
+                get { return stringValue; }
+                set {
+                    if (stringValue != value) {
+                        var oldValue = stringValue;
+                        stringValue = value;
+                        if (stringValueChanged != null) {
+                            stringValueChanged (oldValue, stringValue);
+                        }
+                    }
+                }
+            }
+        }
 
-		[Test]
-		public void NotifyNotEventHandler ()
-		{
-			var obj = new NotEventHandlerObject {
-				StringValue = "Hello",
-			};
-			var left = "";
+        [Test]
+        public void NotifyNotEventHandler ()
+        {
+            var obj = new NotEventHandlerObject {
+                StringValue = "Hello",
+            };
+            var left = "";
 
-			var b = Binding.Create (() => left == obj.StringValue);
+            var b = Binding.Create (() => left == obj.StringValue);
 
-			Assert.AreEqual (1, obj.StringValueChangedCount);
+            Assert.AreEqual (1, obj.StringValueChangedCount);
 
-			Assert.AreEqual (obj.StringValue, left);
+            Assert.AreEqual (obj.StringValue, left);
 
-			obj.StringValue = "Goodbye";
+            obj.StringValue = "Goodbye";
 
-			Assert.AreEqual ("Goodbye", left);
+            Assert.AreEqual ("Goodbye", left);
 
-			b.Unbind ();
+            b.Unbind ();
 
-			Assert.AreEqual (0, obj.StringValueChangedCount);
+            Assert.AreEqual (0, obj.StringValueChangedCount);
 
-			obj.StringValue = "Hello Again";
+            obj.StringValue = "Hello Again";
 
-			Assert.AreEqual ("Goodbye", left);
-		}
-	}
+            Assert.AreEqual ("Goodbye", left);
+        }
+
+        class PlainObject
+        {
+            public string string_property { get; set;}
+        }
+
+        [Test]
+        public void TriggerInvalidateMember()
+        {
+            var obj = new PlainObject {
+                string_property = "Hello",
+            };
+            var left = "";
+
+            var b = Binding.Create (() => left == obj.string_property);
+
+            Assert.AreEqual (obj.string_property, left);
+
+            obj.string_property = "Goodbye";
+
+            Binding.InvalidateMember(() => obj.string_property);
+
+            Assert.AreEqual ("Goodbye", left);
+
+            b.Unbind ();
+
+            obj.string_property = "Hello Again";
+
+            Assert.AreEqual ("Goodbye", left);
+        }
+    }
 }
 


### PR DESCRIPTION
In the docs, there was a way to trigger binding from objects that
didn’t implement [Automatic Change Tracking]. This has now been added.