### PR TITLE
Manual change tracking

### DIFF
--- a/src/Bind.cs
+++ b/src/Bind.cs
@@ -323,6 +323,23 @@ namespace Praeclarum.Bind
 			}
 		}
 
+        /// <summary>
+        /// A nice expression based way to invalidate the specified object member. 
+        /// This will cause all actions associated with that member to be executed.
+        /// This is the main mechanism by which binding values are distributed.
+        /// </summary>
+        /// <param name="lambdaExpr">Lambda expr of the Member of the object that changed</param>
+        /// <typeparam name="T">The 1st type parameter.</typeparam>
+        public static void InvalidateMember<T>(Expression<Func<T>> lambdaExpr)
+        {
+            var body = lambdaExpr.Body;
+            if (body.NodeType == ExpressionType.MemberAccess) {
+                var m = (MemberExpression)body;
+                var obj = Evaluator.EvalExpression(m.Expression);
+                InvalidateMember(obj, m.Member, 0);
+            }
+        }
+
 		#endregion
 	}
 

--- a/test/ChangeTrackingTest.cs
+++ b/test/ChangeTrackingTest.cs
@@ -332,6 +332,36 @@ namespace Praeclarum.Bind.Test
 
 			Assert.AreEqual ("Goodbye", left);
 		}
+
+        class PlainObject
+        {
+            public string string_property { get; set;}
+        }
+
+        [Test]
+        public void TriggerInvalidateMember()
+        {
+            var obj = new PlainObject {
+                string_property = "Hello",
+            };
+            var left = "";
+
+            var b = Binding.Create (() => left == obj.string_property);
+
+            Assert.AreEqual (obj.string_property, left);
+
+            obj.string_property = "Goodbye";
+
+            Binding.InvalidateMember(() => obj.string_property);
+
+            Assert.AreEqual ("Goodbye", left);
+
+            b.Unbind ();
+
+            obj.string_property = "Hello Again";
+
+            Assert.AreEqual ("Goodbye", left);
+        }
 	}
 }
 


### PR DESCRIPTION
In the docs, an `InvalidateMember` method was specified to allow
objects that didn’t implement [Automatic Change Tracking] to bind their
data to some other field. This commit brings back that functionality.
